### PR TITLE
Add comparability with Solarium v3.5

### DIFF
--- a/SolrDataProvider.php
+++ b/SolrDataProvider.php
@@ -7,7 +7,7 @@ use yii\base\Model;
 use yii\base\InvalidConfigException;
 use yii\data\BaseDataProvider;
 use yii\di\Instance;
-use Solarium\Core\Query\Query as SolrQuery;
+use Solarium\Core\Query\QueryInterface as SolrQuery;
 use sammaye\solr\Client;
 
 /**


### PR DESCRIPTION
The class layout was refactored in Solarium v3.5, the
`Solarium\Core\Query\Query` was deprecated and replaced with a stub.
Instances of type `Solarium\QueryType\Select\Query\Query` are used
instead. This breaks tests for the type of `query`.  Since both of the
aforementioned classes implement `QueryInterface`, testing for instances
of that interface fixes the bug while maintaining backward
comparability.