### PR TITLE
Lock solarium Version to 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "solarium/solarium": "*"
+        "solarium/solarium": "~5.0"
     },
     "autoload": {
         "psr-4": { "sammaye\\solr\\": "" }


### PR DESCRIPTION
yii2-solr does not work with the current solarium version (which is 6.x). Probably 5.1 will work.